### PR TITLE
Tie WET version numbers to generator version

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= _.slugify(themeName) %>",
-  "version": "0.0.0",
+  "version": "<%= pkg.version %>",
   "license": "MIT",
   "ignore": [
     "**/.*",
@@ -12,7 +12,7 @@
     "lib"
   ],
   "devDependencies": {
-    "wet-boew": "4.0.1"
+    "wet-boew": "<%= pkg.version %>"
   },
   "resolutions": {
     "jquery": "~2.1.0"

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= _.slugify(themeName) %>",
-  "version": "0.0.0",
+  "version": "<%= pkg.version %>",
   "scripts": {
     "test": "grunt",
     "postinstall": "bower update && cd lib/wet-boew && npm install"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-wet-boew-theme",
-  "version": "0.0.0",
+  "version": "4.0.2",
   "description": "A generator for Yeoman",
   "keywords": [
     "yeoman-generator"
@@ -23,7 +23,7 @@
     "mocha": "~1.12.0"
   },
   "peerDependencies": {
-    "yo": ">=1.0.0-rc.1"
+    "yo": ">=1.1.2"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
Keep the generator in sync with the published version of WET. This would mean we bump and push new versions with each stable like we do for the themes
